### PR TITLE
Creates auth server with password grant

### DIFF
--- a/back-end/access-control/pom.xml
+++ b/back-end/access-control/pom.xml
@@ -22,34 +22,17 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-mail</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-oauth2-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-gateway</artifactId>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.2</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -63,23 +46,16 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security.oauth</groupId>
+			<artifactId>spring-security-oauth2</artifactId>
+			<version>2.3.8.RELEASE</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
+			<artifactId>spring-security-jwt</artifactId>
+			<version>1.0.10.RELEASE</version>
 		</dependency>
 	</dependencies>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/back-end/access-control/src/main/java/com/appdomain/accesscontrol/AccessControlApplication.java
+++ b/back-end/access-control/src/main/java/com/appdomain/accesscontrol/AccessControlApplication.java
@@ -2,8 +2,10 @@ package com.appdomain.accesscontrol;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 
 @SpringBootApplication
+@EnableResourceServer
 public class AccessControlApplication {
 
 	public static void main(String[] args) {

--- a/back-end/access-control/src/main/java/com/appdomain/accesscontrol/configurations/AuthorizationServerConfiguration.java
+++ b/back-end/access-control/src/main/java/com/appdomain/accesscontrol/configurations/AuthorizationServerConfiguration.java
@@ -1,0 +1,71 @@
+package com.appdomain.accesscontrol.configurations;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
+import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
+
+@Configuration
+@EnableAuthorizationServer
+public class AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    public void configure(ClientDetailsServiceConfigurer clients) {
+        try {
+            clients.inMemory()
+                    .withClient("front-end")
+                    .authorizedGrantTypes("password")
+                    .secret(passwordEncoder().encode("a"))
+                    .authorizedGrantTypes("password")
+                    .scopes("any");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    @Override
+    public void configure(AuthorizationServerEndpointsConfigurer endpoints) {
+        endpoints
+                .authenticationManager(authenticationManager)
+                .tokenEnhancer(getTokenEnhancer())
+                .tokenStore(new JwtTokenStore(getTokenEnhancer()))
+                .userDetailsService(userDetailsService);
+    }
+
+    @Override
+    public void configure(AuthorizationServerSecurityConfigurer serverSecurityConfigurer) {
+        serverSecurityConfigurer
+                .tokenKeyAccess("permitAll()")
+                .passwordEncoder(passwordEncoder());
+    }
+
+    @Bean
+    JwtAccessTokenConverter getTokenEnhancer() {
+        JwtAccessTokenConverter jwtAccessTokenConverter = new JwtAccessTokenConverter();
+        jwtAccessTokenConverter.setSigningKey("MXgXfkHLzJgNAuspB3dv");
+        return jwtAccessTokenConverter;
+    }
+
+}

--- a/back-end/access-control/src/main/java/com/appdomain/accesscontrol/configurations/DemoController.java
+++ b/back-end/access-control/src/main/java/com/appdomain/accesscontrol/configurations/DemoController.java
@@ -1,0 +1,16 @@
+package com.appdomain.accesscontrol.configurations;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DemoController {
+
+    @GetMapping("/test")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public String testToken() {
+        return "This User is an Admin";
+    }
+
+}

--- a/back-end/access-control/src/main/java/com/appdomain/accesscontrol/configurations/WebSecurityConfiguration.java
+++ b/back-end/access-control/src/main/java/com/appdomain/accesscontrol/configurations/WebSecurityConfiguration.java
@@ -1,0 +1,48 @@
+package com.appdomain.accesscontrol.configurations;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@EnableWebSecurity
+public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    @Autowired
+    public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
+        authenticationManagerBuilder.authenticationProvider(authenticationProvider());
+    }
+
+    @Override
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailsManager(
+                User.withDefaultPasswordEncoder()
+                        .username("testUser")
+                        .password("Password1!")
+                        .roles("ADMIN")
+                        .build()
+        );
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        final DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService());
+        return provider;
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManager() throws Exception {
+        return super.authenticationManager();
+    }
+}

--- a/back-end/access-control/src/main/resources/application.properties
+++ b/back-end/access-control/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8080/oauth/token_key
+
+logging.level.org.springframework.security=TRACE


### PR DESCRIPTION
A username and password can be exchanged for a jwt token.
The token contains the user role. The token can then be included
as a header in the format
"Authorization": "Bearer (token)"
The api endpoints can then read the role from the token to
verify the user is allowed to access the resource requested.